### PR TITLE
fix: python requirements file is actually called mkdocs_requirements.txt

### DIFF
--- a/installer.md
+++ b/installer.md
@@ -37,7 +37,7 @@ Il y a 3 possibilité pour installer ces modules.
 C'est la meilleure méthode car elle permet de s'assurer que l'on travaille tous sur les mêmes versions.
 
 ```bash
-pip install -r requirements.txt
+pip install -r mkdocs_requirements.txt
 ```
 
 Pour vérifier :

--- a/maintenir.md
+++ b/maintenir.md
@@ -22,7 +22,7 @@ Ouvrir un terminal à la racine de votre clone local du dépôt `georchestra_doc
 - lancer une session Python : `source venv_mkdocs/Scripts/activate`
 - on met à jour les libraires python : 
   - en utilisant les wheels : `python -m pip install --trusted-host pypi.org docs_modules/3.9_windows/*.whl`
-  - ou en utilisant le fichier `requirements.txt` : `pip install -r requirements.txt`
+  - ou en utilisant le fichier `mkdocs_requirements.txt` : `pip install -r mkdocs_requirements.txt`
 - si tout est ok, on vérifie la version de MkDocs : `mkdocs –-version`
 
 

--- a/maintenir_template.md
+++ b/maintenir_template.md
@@ -11,7 +11,7 @@ Mettre à jour manuellement les modules Python si nécessaire.
 ## 2. Figer les dépendances Python
 
 ```bash
-pip freeze > requirements.txt
+pip freeze > mkdocs_requirements.txt
 ```
 
 
@@ -19,7 +19,7 @@ pip freeze > requirements.txt
 
 ```bash
 rm modules/*
-python -m pip wheel -r requirements.txt -w modules/{version python + os}/
+python -m pip wheel -r mkdocs_requirements.txt -w modules/{version python + os}/
 ```
 
 

--- a/readthedocs.md
+++ b/readthedocs.md
@@ -29,7 +29,7 @@ mkdocs:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - requirements: requirements.txt
+   - requirements: mkdocs_requirements.txt
 ```
 
 

--- a/utiliser.md
+++ b/utiliser.md
@@ -25,7 +25,7 @@ Copier les éléments suivants à la racine de votre projet / votre produit geor
 - le répertoire `docs_modules`
 - le fichier de configuration de la documentation `mkdocs.yml`
 - le fichier de configuration de compilation de documentation pour ReadTheDocs `.readthedocs.yaml`
-- le fichier `requirements.txt` pour l'installation de MkDocs sous Python 3.9
+- le fichier `mkdocs_requirements.txt` pour l'installation de MkDocs sous Python 3.9
 
 
 ## Modifier le .gitignore de votre projet
@@ -80,7 +80,7 @@ Il y a 3 possibilité pour installer ces modules et toutes leurs dépendances.
 C'est la meilleure méthode car elle permet de s'assurer que l'on travaille tous sur les mêmes versions. Mais il ne faut pas être bridé au niveau de l'accès à internet.
 
 ```bash
-pip install -r requirements.txt
+pip install -r mkdocs_requirements.txt
 ```
 
 


### PR DESCRIPTION
Fix accordingly in the usage instructions